### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_signed_in, except: [:index]
+  before_action :move_to_signed_in, except: [:index, :show]
   
   def index
     @items = Item.includes(:user).order("created_at DESC")
@@ -18,6 +18,9 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
   private
   def move_to_signed_in
     unless user_signed_in?

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -137,7 +137,7 @@
       <% if @items.exists? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to '#' do %>
+            <%= link_to item_path(item.id) do %>
             <%= image_tag item.image, class: "item-img" %>
               <div class='item-info'>
                 <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,12 +24,14 @@
     </div>
 
     <%# 商品購入機能実装時に購入前後による分岐 %>
-    <% if user_signed_in? && current_user.id == @item.user.id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-      <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <% elsif user_signed_in? && current_user.id != @item.user.id %>
-      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user.id %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% else %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
     <% end %>
     <%# //商品購入機能実装時に購入前後による分岐 %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,105 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.name %>
+    </h2>
+    <div class="item-img-content">
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# <div class="sold-out">
+        <span>Sold Out!!</span>
+      </div> %>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        <%= "¥ #{@item.price.to_s(:delimited)}" %>
+      </span>
+      <span class="item-postage">
+        <%= @item.ship_fee.name %>
+      </span>
+    </div>
+
+    <%# 商品購入機能実装時に購入前後による分岐 %>
+    <% if user_signed_in? && current_user.id == @item.user.id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% elsif user_signed_in? && current_user.id != @item.user.id %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
+    <%# //商品購入機能実装時に購入前後による分岐 %>
+
+    <div class="item-explain-box">
+      <span><%= @item.info %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @item.user.nickname %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= @item.category.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= @item.status.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= @item.ship_fee.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= @item.ship_area.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= @item.ship_schedule.name %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+</div>
+
+<%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
# What
- 商品詳細表示ページは、ログイン状況や商品の販売状況に関係なく、誰でも見ることができること。
- 商品一覧ページにて商品情報をクリックすると、該当する商品の商品詳細表示ページへ遷移すること。
- 商品出品時に登録した情報（商品名・商品画像・価格・配送料の負担・商品の説明・出品者名・カテゴリー・商品の状態・発送元の地域・発送日の目安）が、見本アプリと同様の形で表示されること。
- 画像が表示されており、画像がリンク切れなどにならないこと（デプロイのタスクにあるとおり、実装中にHerokuの仕様による商品画像が適切に表示されなくなる問題は発生するが、最後にS3を導入することで、この問題は解消される）。
- ログイン状態且つ、自身が出品した販売中商品の場合にのみ、「商品の編集」「削除」ボタンが表示されること。
- ログイン状態且つ、自身が出品していない販売中商品の場合にのみ、「購入画面に進む」ボタンが表示されること。
- 【商品購入機能実装時】ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されないこと。
- ログアウト状態の場合は、商品の販売状況に関わらず、「商品の編集」「削除」「購入画面に進む」ボタンが表示されないこと。
- 【商品購入機能実装時】売却済みの商品は、画像上に「sold out」の文字が表示されること。

# Why
商品詳細表示機能実装のため

# プルリクエストへ記載するgyazo
- ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/676d48fda8e92e7f6a93474cf3377df6
- ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/6c45af03a426075c6d42bdb664e4038e
- ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
未実装
- ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/c67ec125d0ffea6fd917d2cce5bf1704