### PR TITLE
追加実装（会員ランク機能）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,4 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'payjp'
 gem "aws-sdk-s3", require: false
+gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,11 @@ GEM
       romaji
     globalid (0.5.2)
       activesupport (>= 5.0)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
@@ -147,6 +152,7 @@ GEM
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
+    multi_json (1.15.0)
     mysql2 (0.5.3)
     netrc (0.11.0)
     nio4r (2.5.8)
@@ -204,6 +210,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.1.1)
+    request_store (1.5.0)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -320,6 +328,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   gimei
+  gon
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | last_name_kana     | string  | null: false               |
 | first_name_kana    | string  | null: false               |
 | birth_date         | date    | null: false               |
+| sell_count         | integer | null: false               |
 
 ### Association
 

--- a/app/assets/stylesheets/shared/header.css
+++ b/app/assets/stylesheets/shared/header.css
@@ -85,6 +85,20 @@
   font-weight: bold;
 }
 
+.user-nickname-gold {
+  text-decoration: none;
+  margin-right: 3vw;
+  color: gold;
+  font-weight: bold;
+}
+
+.user-nickname-silver {
+  text-decoration: none;
+  margin-right: 3vw;
+  color: silver;
+  font-weight: bold;
+}
+
 
 .logout {
   text-decoration: none;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,7 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
+    gon.currentUserSellCount = current_user.sell_count
   end
 
   def create

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -9,9 +9,12 @@ class PurchasesController < ApplicationController
   
   def create
     @purchase_ship_address = PurchaseShipAddress.new(purchase_params)
+    user = User.find(@item.user_id)
     if @purchase_ship_address.valid?
       pay_item
       @purchase_ship_address.save
+      user.sell_count += 1
+      user.save
       redirect_to root_path
     else
       render :index

--- a/app/javascript/item.js
+++ b/app/javascript/item.js
@@ -3,7 +3,14 @@ window.addEventListener('load', () => {
   itemPrice.addEventListener("input", () => {
     const itemPriceValue = itemPrice.value;
     const addTaxPrice = document.getElementById("add-tax-price");
-    const addTaxPriceValue = Math.floor(itemPriceValue * 0.1);
+    if (gon.currentUserSellCount >= 5) {
+      var rankCoef = 0.05;
+    } else if (gon.currentUserSellCount >= 3) {
+      var rankCoef = 0.08;
+    } else {
+      var rankCoef = 0.1;
+    }
+    const addTaxPriceValue = Math.floor(itemPriceValue * rankCoef);
     addTaxPrice.innerHTML = addTaxPriceValue;
     const profit = document.getElementById("profit");
     profit.innerHTML = itemPriceValue - addTaxPriceValue;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   with_options presence: true do
     validates :nickname
-    validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i }
+    validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i }, on: :create
     validates :birth_date
   end
   with_options presence: true, format: { with: /\A[ぁ-んァ-ン一-龥々ー]+\z/ } do

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -100,7 +100,13 @@
           <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
-          <span>販売手数料 (10%)</span>
+          <% if current_user.sell_count >= 5 %>
+            <span>販売手数料 (Gold会員は5%！)</span>
+          <% elsif current_user.sell_count >= 3 %>
+            <span>販売手数料 (Silver会員は8%！)</span>
+          <% else %>
+            <span>販売手数料 (10%)</span>
+          <% end %>
           <span>
             <span id='add-tax-price'></span>円
           </span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <script type="text/javascript" src="https://js.pay.jp/v1/"></script>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= include_gon %>
   </head>
 
   <body>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,7 +16,13 @@
     </ul>
     <ul class='lists-right'>
       <% if user_signed_in? %>
+        <% if current_user.sell_count >= 5 %>
+        <li><%= link_to current_user.nickname, "#", class: "user-nickname-gold" %> </li>
+        <% elsif current_user.sell_count >= 3 %>
+        <li><%= link_to current_user.nickname, "#", class: "user-nickname-silver" %> </li>
+        <% else %>
         <li><%= link_to current_user.nickname, "#", class: "user-nickname" %> </li>
+        <% end %>
         <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "logout" %> </li>
       <% else %>
         <li><%= link_to 'ログイン', new_user_session_path, class: "login" %></li>

--- a/db/migrate/20210818091507_add_rank_to_users.rb
+++ b/db/migrate/20210818091507_add_rank_to_users.rb
@@ -1,0 +1,5 @@
+class AddRankToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :sell_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_13_071534) do
+ActiveRecord::Schema.define(version: 2021_08_18_091507) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2021_08_13_071534) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "sell_count", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# What
販売数による会員ランク設定
- usersテーブルにsell_countカラムを追加
- 販売時にsell_countが増加
- ランクによるheaderの会員名文字色変更
- ランクによる販売手数料の変動

# Why
利用率による特典を追加するため
- Gold会員は5回以上販売した場合に販売手数料5%に設定
- Silver会員は3回以上販売した場合に販売手数料8%に設定